### PR TITLE
Add website link to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Authors@R: c(
 Description: Data on Asylum and Resettlement for the UK,
     provided by the Home Office <https://www.gov.uk/government/statistical-data-sets/immigration-system-statistics-data-tables>.
 License: MIT + file LICENSE
-URL: https://github.com/humaniverse/asylum
+URL: https://humaniverse.github.io/asylum/, https://github.com/humaniverse/asylum
 BugReports: https://github.com/humaniverse/asylum/issues
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
You may benefit from adding it also in the About page in Github.

![image](https://github.com/humaniverse/asylum/assets/52606734/7333021f-2334-4c35-9121-6c5512d9702b)
